### PR TITLE
Update GitHub Actions workflow for cktap-direct

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,12 @@ on:
   push:
     branches:
       - 'master'
+      - 'main'
       - 'release/*'
   pull_request:
     branches:
       - 'master'
+      - 'main'
       - 'release/*'
 
 name: CI
@@ -35,8 +37,8 @@ jobs:
           profile: minimal
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.2.1
-      - name: Install libpcsclite-dev
-        run: sudo apt install libpcsclite-dev
+      - name: Install libusb
+        run: sudo apt install libusb-1.0-0-dev
       - name: Use MSRV Cargo.toml # Don't include "cli" in workspace if using MSRV
         if: ${{ matrix.rust.msrv }}
         run: cp Cargo.toml.MSRV Cargo.toml
@@ -44,6 +46,29 @@ jobs:
         run: cargo build ${{ matrix.features }}
       - name: Test
         run: cargo test ${{ matrix.features }}
+
+  build_static_musl:
+    name: Build static musl binary
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Install Rust toolchain with musl target
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-musl
+          override: true
+          profile: minimal
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.1
+      - name: Install musl-tools
+        run: sudo apt install musl-tools
+      - name: Build static binary
+        run: |
+          cargo build --release --target x86_64-unknown-linux-musl
+          # Verify it's actually static
+          ldd target/x86_64-unknown-linux-musl/release/cktap-direct 2>&1 | grep -q "statically linked"
 
   rust_fmt:
     name: Rust fmt
@@ -73,8 +98,8 @@ jobs:
           override: true
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.2.1
-      - name: Install libpcsclite-dev
-        run: sudo apt install libpcsclite-dev
+      - name: Install libusb
+        run: sudo apt install libusb-1.0-0-dev
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Updates the GitHub Actions CI workflow to work with the new direct USB implementation.

## Changes
- Replace `libpcsclite-dev` dependency with `libusb-1.0-0-dev`
- Add new job `build_static_musl` to build and verify static binaries
- Add support for both 'master' and 'main' branches
- Verify static binary compilation with `ldd` check

## Why
The original workflow was designed for PC/SC dependencies. Now that we use direct USB via `rusb`/`libusb`, we need to:
1. Install the correct system dependencies
2. Test that our main feature (static binary compilation) actually works

The new workflow ensures that PRs and commits are tested with the correct dependencies and that static musl binaries are properly built.