### PR TITLE
Remove CLAUDE.md from git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /target
 /Cargo.lock
 
+# Local development files
+CLAUDE.md
+
 # IDE
 /.vscode
 /.idea

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,227 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is `cktap-direct`, a Rust library and CLI tool for communicating directly with Coinkite TapSigner and SatsCard devices via USB CCID protocol. This is a fork of `rust-cktap` that replaces PC/SC middleware dependencies with pure Rust USB communication, enabling static musl binary compilation.
+
+## Development Commands
+
+### Build & Run
+```bash
+# Build the project
+nix develop -c cargo build
+
+# Build release
+nix develop -c cargo build --release
+
+# Build static musl binary
+nix develop -c cargo build --release --target x86_64-unknown-linux-musl
+
+# Run CLI
+nix develop -c cargo run --bin cktap-direct -- [ARGS]
+
+# Test with TapSigner
+CKTAP_CVC=123456 nix develop -c cargo run --bin cktap-direct -- derive --path 84,0,0,0,0
+```
+
+### Testing & Quality
+```bash
+# Run tests
+nix develop -c cargo test
+
+# Format code
+nix develop -c cargo fmt --all
+
+# Check formatting
+nix develop -c cargo fmt --all -- --config format_code_in_doc_comments=true --check
+
+# Run clippy
+nix develop -c cargo clippy --all-features --all-targets -- -D warnings
+
+# Test specific configurations
+nix develop -c cargo test --no-default-features
+nix develop -c cargo test --features default
+```
+
+## Git Workflow
+
+### Branch Naming Convention
+
+Use descriptive branch names following this pattern:
+- `feature/description` - New features
+- `fix/description` - Bug fixes 
+- `chore/description` - Maintenance tasks
+- `docs/description` - Documentation updates
+- `refactor/description` - Code refactoring
+
+**Examples:**
+- `feature/add-satscard-unseal`
+- `fix/usb-timeout-handling`
+- `chore/upgrade-rust-edition-2024`
+- `docs/update-api-examples`
+
+### Development Workflow
+
+1. **Create a new branch for each change:**
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. **Make your changes and test locally:**
+   ```bash
+   # Always test before committing
+   nix develop -c cargo test
+   nix develop -c cargo clippy --all-features --all-targets -- -D warnings
+   nix develop -c cargo fmt --all -- --config format_code_in_doc_comments=true --check
+   ```
+
+3. **Commit with descriptive messages:**
+   ```bash
+   git add .
+   git commit -m "feat: add support for new feature
+   
+   - Implement specific functionality
+   - Add tests for edge cases
+   - Update documentation"
+   ```
+
+4. **Push and create PR:**
+   ```bash
+   git push origin feature/your-feature-name
+   # Create PR via GitHub CLI or web interface
+   nix develop -c gh pr create --title "Add new feature" --body "Description of changes"
+   ```
+
+### Commit Message Format
+
+Use conventional commit format:
+- `feat:` - New features
+- `fix:` - Bug fixes
+- `docs:` - Documentation changes
+- `style:` - Code style changes (formatting, etc.)
+- `refactor:` - Code refactoring
+- `test:` - Adding or updating tests
+- `chore:` - Maintenance tasks
+- `ci:` - CI/CD changes
+
+### Quality Requirements
+
+**Before any commit:**
+1. Code must format correctly: `cargo fmt --all`
+2. Code must pass clippy: `cargo clippy --all-features --all-targets -- -D warnings`
+3. All tests must pass: `cargo test`
+4. Static musl build must work: `cargo build --release --target x86_64-unknown-linux-musl`
+
+**Never commit:**
+- Backup files (*.backup, *.bak)
+- Temporary files
+- IDE-specific files
+- Proposal or documentation drafts not intended for the repo
+
+## Architecture
+
+### Module Structure
+- `lib/src/` - Core library code
+  - `apdu.rs` - APDU command/response definitions
+  - `ccid.rs` - CCID protocol implementation
+  - `usb_transport.rs` - USB communication layer
+  - `discovery.rs` - Device discovery and enumeration
+  - `commands.rs` - High-level command trait
+  - `sats_card.rs` - SatsCard-specific functionality
+  - `tap_signer.rs` - TapSigner-specific functionality
+- `cli/src/main.rs` - CLI application
+- `cktap-ffi/` - FFI bindings for other languages
+
+### Key Patterns
+
+1. **Error Handling**: Uses `thiserror` for structured errors and `anyhow` for CLI
+2. **Async**: Built on Tokio with async/await throughout
+3. **USB Communication**: Direct CCID protocol over USB bulk transfers
+4. **Transport Abstraction**: `CkTransport` trait allows pluggable backends
+
+### Environment Variables
+- `CKTAP_CVC` - Card Verification Code for testing
+- `RUST_LOG` - Control logging level (default: info)
+
+## Development Environment
+
+### Using Nix
+The project uses Nix flakes for reproducible development environments:
+
+```bash
+# Enter development shell with all dependencies
+nix develop
+
+# Run commands in the shell
+nix develop -c cargo build
+nix develop -c cargo test
+```
+
+The Nix environment provides:
+- Rust toolchain with musl target
+- Static libusb and libudev libraries
+- pkg-config and build tools
+- GitHub CLI (gh)
+
+### Dependencies
+- **Core**: Rust with edition 2024
+- **USB**: rusb (libusb wrapper)
+- **Crypto**: bitcoin crate with secp256k1
+- **Serialization**: ciborium (CBOR), serde
+- **CLI**: clap for argument parsing
+
+## Testing
+
+### Hardware Testing
+- Requires physical TapSigner or SatsCard device
+- Test with various card readers (OMNIKEY preferred)
+- Verify static binary deployment
+
+### Unit Tests
+```bash
+# Run all tests
+nix develop -c cargo test
+
+# Test specific modules
+nix develop -c cargo test ccid::
+nix develop -c cargo test usb_transport::
+nix develop -c cargo test discovery::
+```
+
+### Integration Testing
+```bash
+# Test with real hardware (requires device)
+CKTAP_CVC=123456 nix develop -c cargo run --bin cktap-direct -- debug
+```
+
+## Deployment
+
+### Static Binary
+```bash
+# Build portable static binary
+nix develop -c cargo build --release --target x86_64-unknown-linux-musl
+
+# Verify it's static
+ldd target/x86_64-unknown-linux-musl/release/cktap-direct
+```
+
+## Troubleshooting
+
+### Common Issues
+1. **USB permissions**: Add udev rules or run with elevated privileges
+2. **Card reader compatibility**: OMNIKEY readers work best
+3. **Static linking**: Use Nix environment for proper library configuration
+
+### Debug Commands
+```bash
+# List USB devices
+lsusb
+
+# Check for CCID readers
+nix develop -c cargo run --example usb_test
+
+# Enable debug logging
+RUST_LOG=debug nix develop -c cargo run --bin cktap-direct -- debug
+```

--- a/cktap-ffi/Cargo.toml
+++ b/cktap-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cktap-direct-ffi"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 [lib]

--- a/cktap-ffi/src/lib.rs
+++ b/cktap-ffi/src/lib.rs
@@ -1,7 +1,7 @@
 uniffi::setup_scaffolding!();
 
 use cktap_direct::apdu::{AppletSelect, CommandApdu, ResponseApdu, StatusResponse};
-use cktap_direct::{rand_nonce as core_rand_nonce, Error as CoreError};
+use cktap_direct::{Error as CoreError, rand_nonce as core_rand_nonce};
 use std::fmt::Debug;
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cktap-direct-cli"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "cktap-direct"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,9 +3,9 @@ use cktap_direct::commands::{CkTransport, Read};
 use cktap_direct::discovery;
 #[cfg(feature = "emulator")]
 use cktap_direct::emulator;
-use cktap_direct::secp256k1::hashes::{hex::DisplayHex, Hash as _};
+use cktap_direct::secp256k1::hashes::{Hash as _, hex::DisplayHex};
 use cktap_direct::secp256k1::rand;
-use cktap_direct::{apdu::Error, commands::Certificate, rand_chaincode, CkTapCard};
+use cktap_direct::{CkTapCard, apdu::Error, commands::Certificate, rand_chaincode};
 /// CLI for cktap-direct
 use clap::{Parser, Subcommand};
 use rpassword::read_password;

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cktap-direct"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/lib/examples/usb_test.rs
+++ b/lib/examples/usb_test.rs
@@ -1,5 +1,5 @@
-use cktap_direct::discovery;
 use cktap_direct::CkTapCard;
+use cktap_direct::discovery;
 
 #[tokio::main]
 async fn main() -> Result<(), cktap_direct::Error> {

--- a/lib/src/apdu.rs
+++ b/lib/src/apdu.rs
@@ -3,8 +3,8 @@
 pub mod tap_signer;
 
 use bitcoin::secp256k1::{
-    self, ecdh::SharedSecret, ecdsa::Signature, hashes::hex::DisplayHex, PublicKey, SecretKey,
-    XOnlyPublicKey,
+    self, PublicKey, SecretKey, XOnlyPublicKey, ecdh::SharedSecret, ecdsa::Signature,
+    hashes::hex::DisplayHex,
 };
 use ciborium::de::from_reader;
 use ciborium::ser::into_writer;

--- a/lib/src/apdu/tap_signer.rs
+++ b/lib/src/apdu/tap_signer.rs
@@ -2,7 +2,7 @@ use core::fmt::{self, Formatter};
 
 use super::{CommandApdu, ResponseApdu};
 
-use bitcoin::secp256k1::{hashes::hex::DisplayHex as _, PublicKey};
+use bitcoin::secp256k1::{PublicKey, hashes::hex::DisplayHex as _};
 use serde::{Deserialize, Serialize};
 
 // MARK: - XpubCommand

--- a/lib/src/commands.rs
+++ b/lib/src/commands.rs
@@ -1,11 +1,11 @@
 use crate::factory_root_key::FactoryRootKey;
-use crate::{apdu::*, rand_nonce};
 use crate::{CkTapCard, SatsCard, TapSigner};
+use crate::{apdu::*, rand_nonce};
 
 use bitcoin::key::rand;
 use bitcoin::secp256k1::ecdh::SharedSecret;
 use bitcoin::secp256k1::ecdsa::{RecoverableSignature, RecoveryId, Signature};
-use bitcoin::secp256k1::hashes::{sha256, Hash};
+use bitcoin::secp256k1::hashes::{Hash, sha256};
 use bitcoin::secp256k1::{self, All, Message, PublicKey, Secp256k1, SecretKey};
 
 use std::convert::TryFrom;
@@ -243,8 +243,8 @@ where
 mod tests {
     use super::*;
 
-    use crate::emulator::find_emulator;
     use crate::emulator::CVC;
+    use crate::emulator::find_emulator;
     use crate::rand_chaincode;
 
     #[tokio::test]

--- a/lib/src/discovery.rs
+++ b/lib/src/discovery.rs
@@ -1,4 +1,4 @@
-use crate::usb_transport::{find_ccid_endpoints, UsbTransport};
+use crate::usb_transport::{UsbTransport, find_ccid_endpoints};
 use crate::{CkTapCard, CkTransport, Error};
 use log::{debug, info};
 use rusb::{Context, Device, DeviceDescriptor, DeviceHandle, UsbContext};
@@ -232,8 +232,10 @@ mod tests {
         assert_eq!(COINKITE_VENDOR_ID, 0xD13E);
 
         // Test product lookup
-        assert!(COINKITE_PRODUCTS
-            .iter()
-            .any(|(pid, name)| { *pid == 0xCC10 && *name == "TAPSIGNER" }));
+        assert!(
+            COINKITE_PRODUCTS
+                .iter()
+                .any(|(pid, name)| { *pid == 0xCC10 && *name == "TAPSIGNER" })
+        );
     }
 }

--- a/lib/src/emulator.rs
+++ b/lib/src/emulator.rs
@@ -1,6 +1,6 @@
+use crate::CkTapCard;
 use crate::apdu::{AppletSelect, CommandApdu, Error, StatusCommand};
 use crate::commands::CkTransport;
-use crate::CkTapCard;
 use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::Path;

--- a/lib/src/factory_root_key.rs
+++ b/lib/src/factory_root_key.rs
@@ -1,6 +1,6 @@
 use crate::apdu::Error;
-use bitcoin::secp256k1::hashes::hex::DisplayHex;
 use bitcoin::secp256k1::PublicKey;
+use bitcoin::secp256k1::hashes::hex::DisplayHex;
 use std::convert::TryFrom;
 use std::fmt;
 use std::fmt::Debug;

--- a/lib/src/sats_card.rs
+++ b/lib/src/sats_card.rs
@@ -1,6 +1,6 @@
-use bitcoin::hashes::{sha256, Hash as _};
+use bitcoin::hashes::{Hash as _, sha256};
 use bitcoin::key::CompressedPublicKey as BitcoinPublicKey;
-use bitcoin::secp256k1::{ecdsa::Signature, All, Message, PublicKey, Secp256k1};
+use bitcoin::secp256k1::{All, Message, PublicKey, Secp256k1, ecdsa::Signature};
 use bitcoin::{Address, Network};
 
 use crate::apdu::{

--- a/lib/src/tap_signer.rs
+++ b/lib/src/tap_signer.rs
@@ -1,15 +1,14 @@
 use bitcoin::secp256k1::{
-    self,
+    self, All, Message, PublicKey, Secp256k1,
     ecdsa::Signature,
-    hashes::{sha256, Hash as _},
-    All, Message, PublicKey, Secp256k1,
+    hashes::{Hash as _, sha256},
 };
 use log::error;
 
 use crate::apdu::{
-    tap_signer::{BackupCommand, BackupResponse, ChangeCommand, ChangeResponse},
     CommandApdu as _, DeriveCommand, DeriveResponse, Error, NewCommand, NewResponse, SignCommand,
     SignResponse, StatusCommand, StatusResponse,
+    tap_signer::{BackupCommand, BackupResponse, ChangeCommand, ChangeResponse},
 };
 use crate::commands::{Authentication, Certificate, CkTransport, Read, Wait};
 

--- a/lib/src/usb_transport.rs
+++ b/lib/src/usb_transport.rs
@@ -1,6 +1,6 @@
+use crate::Error;
 use crate::ccid::{CcidCommand, CcidResponse, SlotError, SlotStatus, VoltageSelection};
 use crate::commands::CkTransport;
-use crate::Error;
 use rusb::{Context, DeviceHandle};
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;


### PR DESCRIPTION
## Summary

Remove CLAUDE.md from git tracking and add it to .gitignore.

## Changes

- Remove CLAUDE.md from repository (remains as local development file only)
- Add CLAUDE.md to .gitignore to prevent accidental commits
- File continues to provide development guidance locally

## Rationale

CLAUDE.md is intended as a local-only development guidance file and should not be committed to the repository.