### PR TITLE
Add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /target
 /Cargo.lock
 
+# Local development files
+CLAUDE.md
+
 # IDE
 /.vscode
 /.idea


### PR DESCRIPTION
## Summary

Add CLAUDE.md to .gitignore to prevent accidental commits.

## Changes

- Add CLAUDE.md to .gitignore under "Local development files" section

## Rationale

CLAUDE.md is a local development guidance file that should not be committed to the repository.