### PR TITLE
chore: upgrade dependencies to latest versions

### DIFF
--- a/cktap-ffi/Cargo.toml
+++ b/cktap-ffi/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["staticlib"]
 [dependencies]
 cktap-direct = { path = "../lib" }
 uniffi = { version = "0.29", features = ["cli"] }
-thiserror = "1.0"
+thiserror = "2.0"
 
 [features]
 default = []

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,15 +12,15 @@ path = "src/main.rs"
 
 [dependencies]
 cktap-direct = { path = "../lib" }
-clap = { version = "4.3.1", features = ["derive"] }
-rpassword = { version = "7.2" }
+clap = { version = "4.5.45", features = ["derive"] }
+rpassword = { version = "7.4" }
 tokio = { version = "1", features = ["full"] }
-env_logger = "0.10"
+env_logger = "0.11"
 bitcoin = "0.32"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
-strum = { version = "0.26", features = ["derive"] }
+strum = { version = "0.27", features = ["derive"] }
 
 [features]
 emulator = ["cktap-direct/emulator"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -11,12 +11,12 @@ name = "cktap_direct"
 
 
 [dependencies]
-ciborium = "0.2.0"
+ciborium = "0.2.2"
 serde = "1"
 serde_bytes = "0.11"
 
 # async
-tokio = { version = "1.44", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.47", features = ["macros", "rt-multi-thread"] }
 
 # error handling
 thiserror = "2.0"
@@ -35,7 +35,7 @@ default = []
 emulator = []
 
 [dev-dependencies]
-env_logger = "0.10"
+env_logger = "0.11"
 
 [[example]]
 name = "usb_test"


### PR DESCRIPTION
## Summary
This PR upgrades all project dependencies to their latest versions using `cargo upgrade --incompatible`.

## Changes
### Major version updates:
- **thiserror**: 1.0 → 2.0 (in cktap-ffi)
- **env_logger**: 0.10 → 0.11
- **strum**: 0.26 → 0.27

### Minor/patch updates:
- **clap**: 4.3.1 → 4.5.45
- **rpassword**: 7.2 → 7.4
- **ciborium**: 0.2.0 → 0.2.2
- **tokio**: 1.44 → 1.47

## Test Plan
- [x] All unit tests pass
- [x] Code builds successfully with `cargo build`
- [x] Formatting check passes with `cargo fmt --check`
- [x] Clippy passes with no warnings `cargo clippy -- -D warnings`
- [x] Static musl build works correctly

## Breaking Changes
None - all dependency updates maintain backward compatibility.